### PR TITLE
Add Elastic stack Docker setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Elastic Version zentral steuern (8.16.x ist aktuell verbreitet; bei Bedarf anpassen)
+STACK_VERSION=8.16.3
+
+# Superuser-Passwort für Elasticsearch (auch für Kibana/Fleet in diesem Setup)
+ELASTIC_PASSWORD=ChangeMe_please_!2025
+
+# JVM & Ressourcen
+ES_JAVA_OPTS=-Xms1g -Xmx1g

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f
+
+ps:
+	docker compose ps
+
+rebuild:
+	docker compose pull && docker compose up -d --remove-orphans

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# ELK-Starter
+# ELK Starter
+
+Dieses Repository enthält ein Docker-Compose-Setup für einen einzelnen Elasticsearch-Knoten, Kibana und einen Fleet Server. Die Konfiguration basiert auf den Vorgaben aus `agents.md` und ist für Labor- bzw. Entwicklungsumgebungen gedacht.
+
+## Quickstart
+
+```bash
+# Provisionierung (Docker & Kernel-Tuning)
+sudo bash scripts/provision.sh
+
+# Stack starten
+docker compose up -d
+```
+
+Danach stehen die Dienste unter den folgenden Ports zur Verfügung:
+
+- Elasticsearch: http://localhost:9200
+- Kibana: http://localhost:5601
+- Fleet Server: http://localhost:8220
+
+Für eine erste Überprüfung:
+
+```bash
+curl -s -u elastic:$ELASTIC_PASSWORD http://localhost:9200 | jq .
+```
+
+## Verzeichnisstruktur
+
+Alle persistenten Daten und Logs werden außerhalb der Container unter `/mnt/elastic_logs/` abgelegt:
+
+```
+/mnt/elastic_logs/
+  elasticsearch/{config,data,logs}
+  kibana/{config,logs}
+  fleet-server/{agent,logs}
+```
+
+Weitere Hinweise zu Betrieb und Sicherheit finden sich in `agents.md`.

--- a/configs/elasticsearch/elasticsearch.yml
+++ b/configs/elasticsearch/elasticsearch.yml
@@ -1,0 +1,20 @@
+cluster.name: docker-cluster
+node.name: es01
+discovery.type: single-node
+
+# Logging-Tuning (optional)
+logger.level: info
+
+# Achtung: Dieses Setup nutzt HTTP ohne TLS (nur Dev!)
+xpack.security.enabled: true
+xpack.security.http.ssl:
+  enabled: false
+xpack.security.transport.ssl:
+  enabled: false
+
+path:
+  data: /usr/share/elasticsearch/data
+  logs: /usr/share/elasticsearch/logs
+
+# Für Docker-Umgebungen üblich:
+network.host: 0.0.0.0

--- a/configs/kibana/kibana.yml
+++ b/configs/kibana/kibana.yml
@@ -1,0 +1,21 @@
+server.host: 0.0.0.0
+server.publicBaseUrl: ${SERVER_PUBLICBASEURL:http://localhost:5601}
+
+# Verbindung zu ES (hier via Superuser – für Produktion separat absichern!)
+elasticsearch.hosts: ["http://es01:9200"]
+elasticsearch.username: ${ELASTICSEARCH_USERNAME:elastic}
+elasticsearch.password: ${ELASTIC_PASSWORD}
+
+# File-Logging aktivieren (statt nur stdout)
+logging:
+  appenders:
+    file:
+      type: file
+      fileName: /usr/share/kibana/logs/kibana.log
+      layout:
+        type: json
+  root:
+    level: info
+    appenders: [file]
+
+xpack.security.enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,95 @@
+version: "3.9"
+
+name: elk-stack
+
+networks:
+  elk-net:
+    name: elk-net
+    driver: bridge
+
+services:
+  es01:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    container_name: es01
+    restart: unless-stopped
+    environment:
+      - node.name=es01
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - ES_JAVA_OPTS=${ES_JAVA_OPTS}
+      # Security an, HTTP ohne TLS (dev)
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+      # Logs in Datei (wird gemountet)
+      - path.logs=/usr/share/elasticsearch/logs
+      # Benutzerpasswort (Superuser)
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - /mnt/elastic_logs/elasticsearch/data:/usr/share/elasticsearch/data
+      - /mnt/elastic_logs/elasticsearch/logs:/usr/share/elasticsearch/logs
+      - ./configs/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+    networks:
+      - elk-net
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:${STACK_VERSION}
+    container_name: kibana
+    restart: unless-stopped
+    depends_on:
+      - es01
+    environment:
+      # Fürs Bootstrapping verwenden wir den elastic-User
+      - ELASTICSEARCH_HOSTS=http://es01:9200
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD}
+      # Optional: öffentlich erreichbare Basis-URL (für Links)
+      - SERVER_PUBLICBASEURL=${KIBANA_PUBLIC_URL:-http://localhost:5601}
+    ports:
+      - "5601:5601"
+    volumes:
+      - ./configs/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
+      - /mnt/elastic_logs/kibana/logs:/usr/share/kibana/logs
+    networks:
+      - elk-net
+
+  fleet-server:
+    image: docker.elastic.co/beats/elastic-agent:${STACK_VERSION}
+    container_name: fleet-server
+    restart: unless-stopped
+    depends_on:
+      - es01
+      - kibana
+    environment:
+      # Fleet Server aktivieren & an ES/Kibana koppeln (HTTP, ohne TLS)
+      - FLEET_SERVER_ENABLE=1
+      - FLEET_SERVER_ELASTICSEARCH_HOST=http://es01:9200
+      - FLEET_SERVER_INSECURE_HTTP=true
+      # (Ab neueren Releases erledigt Kibana die Fleet-Initialisierung selbst.
+      #  KIBANA_FLEET_SETUP kann i.d.R. entfallen.)
+      - KIBANA_HOST=http://kibana:5601
+      - KIBANA_USERNAME=elastic
+      - KIBANA_PASSWORD=${ELASTIC_PASSWORD}
+      # Gemeinsame ES-Creds (werden auch vom Agent genutzt)
+      - ELASTICSEARCH_HOST=http://es01:9200
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD}
+      - LOG_LEVEL=info
+    ports:
+      - "8220:8220"
+    volumes:
+      # Persistente Agent-/Fleet-Server-Daten & -Logs
+      - /mnt/elastic_logs/fleet-server/agent:/usr/share/elastic-agent
+      - /mnt/elastic_logs/fleet-server/logs:/var/log/elastic-agent
+    networks:
+      - elk-net

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Root-Check ---
+if [[ $EUID -ne 0 ]]; then
+  echo "Bitte mit sudo/root ausführen."
+  exit 1
+fi
+
+# --- OS-Erkennung (Debian/Ubuntu) ---
+. /etc/os-release
+if [[ "$ID" != "debian" && "$ID" != "ubuntu" ]]; then
+  echo "Dieses Provisioning-Script unterstützt offiziell Debian/Ubuntu."
+  echo "Passe ggf. die Docker-Installation für deine Distribution an."
+fi
+
+# --- Pakete & Docker installieren ---
+apt-get update -y
+apt-get install -y ca-certificates curl gnupg lsb-release jq
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/${ID}/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/${ID} \
+  $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+systemctl enable --now docker
+
+# --- Kernel-Tuning für Elasticsearch ---
+# vm.max_map_count muss >= 262144 sein
+sysctl -w vm.max_map_count=262144
+if ! grep -q "vm.max_map_count=262144" /etc/sysctl.conf; then
+  echo "vm.max_map_count=262144" >> /etc/sysctl.conf
+fi
+
+# --- Verzeichnisstruktur anlegen & Rechte setzen ---
+mkdir -p /mnt/elastic_logs/elasticsearch/{config,data,logs}
+mkdir -p /mnt/elastic_logs/kibana/{config,logs}
+mkdir -p /mnt/elastic_logs/fleet-server/{agent,logs}
+
+# UID/GID 1000 ist Standard in Elastic/Kibana-Container
+chown -R 1000:1000 /mnt/elastic_logs/elasticsearch
+chown -R 1000:1000 /mnt/elastic_logs/kibana
+# Fleet Server (Elastic Agent) läuft oft als root im Container:
+chown -R 0:0 /mnt/elastic_logs/fleet-server || true
+
+chmod -R 0775 /mnt/elastic_logs
+
+echo "Provisionierung abgeschlossen."
+docker --version
+docker compose version

--- a/systemd/elk-stack.service
+++ b/systemd/elk-stack.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=ELK + Fleet Server (docker compose)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/elk-stack
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+RemainAfterExit=yes
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add environment, compose, configs and provisioning script for Elasticsearch, Kibana and Fleet Server
- document quickstart and directory layout

## Testing
- `bash -n scripts/provision.sh`
- `python - <<'PY'
import yaml, sys, pathlib
for path in ["docker-compose.yml", "configs/elasticsearch/elasticsearch.yml", "configs/kibana/kibana.yml"]:
    with open(path) as f:
        yaml.safe_load(f)
print("YAML OK")
PY`
- `docker compose config` *(fails: command not found)*
- `pip install docker-compose` *(fails: Getting requirements to build wheel did not run successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a2a743988333a112125da98f9694