### PR TITLE
Add Elastic Agent installer scripts for Linux and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ELK Starter
 
+
 Dieses Repository enthält ein Docker-Compose-Setup für einen einzelnen Elasticsearch-Knoten, Kibana und einen Fleet Server. Die Konfiguration basiert auf den Vorgaben aus `agents.md` und ist für Labor- bzw. Entwicklungsumgebungen gedacht.
 
 ## Quickstart
@@ -23,6 +24,25 @@ Für eine erste Überprüfung:
 ```bash
 curl -s -u elastic:$ELASTIC_PASSWORD http://localhost:9200 | jq .
 ```
+
+## Elastic Agent installieren
+
+Das Repository enthält Skripte zur Installation eines Elastic Agents, der sich automatisch beim mitgelieferten Fleet Server anmeldet.
+
+### Linux
+
+```bash
+ENROLLMENT_TOKEN=<token> bash scripts/install-agent-linux.sh
+```
+
+### Windows (PowerShell)
+
+```powershell
+.\scripts\install-agent-windows.ps1 -EnrollmentToken <token>
+```
+
+Beide Skripte verwenden standardmäßig die in `.env` definierte Version (`STACK_VERSION`). Für die aktuelle Version ist der Elastic Agent als Download verfügbar, sodass der aktuelle Agent genutzt werden kann.
+
 
 ## Verzeichnisstruktur
 

--- a/scripts/install-agent-linux.sh
+++ b/scripts/install-agent-linux.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Elastic Agent version to install. Defaults to STACK_VERSION from .env or 8.16.3.
+AGENT_VERSION="${AGENT_VERSION:-${STACK_VERSION:-8.16.3}}"
+FLEET_URL="${FLEET_URL:-http://localhost:8220}"
+
+if [[ -z "${ENROLLMENT_TOKEN:-}" ]]; then
+  echo "ENROLLMENT_TOKEN environment variable must be set" >&2
+  exit 1
+fi
+
+TARBALL="elastic-agent-${AGENT_VERSION}-linux-x86_64.tar.gz"
+DOWNLOAD_URL="https://artifacts.elastic.co/downloads/beats/elastic-agent/${TARBALL}"
+
+# Download and extract Elastic Agent
+curl -fL -O "$DOWNLOAD_URL"
+tar -xzf "$TARBALL"
+cd "elastic-agent-${AGENT_VERSION}-linux-x86_64"
+
+# Install and enroll the agent non-interactively
+sudo ./elastic-agent install \
+  --url "$FLEET_URL" \
+  --enrollment-token "$ENROLLMENT_TOKEN" \
+  --insecure \
+  -b

--- a/scripts/install-agent-windows.ps1
+++ b/scripts/install-agent-windows.ps1
@@ -1,0 +1,33 @@
+Param(
+    [string]$AgentVersion = $env:AGENT_VERSION,
+    [string]$FleetUrl = $env:FLEET_URL,
+    [Parameter(Mandatory=$true)] [string]$EnrollmentToken
+)
+
+if (-not $AgentVersion) {
+    if ($env:STACK_VERSION) {
+        $AgentVersion = $env:STACK_VERSION
+    } else {
+        $AgentVersion = '8.16.3'
+    }
+}
+
+if (-not $FleetUrl) {
+    $FleetUrl = 'http://localhost:8220'
+}
+
+$Zip = "elastic-agent-$AgentVersion-windows-x86_64.zip"
+$DownloadUrl = "https://artifacts.elastic.co/downloads/beats/elastic-agent/$Zip"
+
+Invoke-WebRequest -Uri $DownloadUrl -OutFile $Zip
+Expand-Archive -Path $Zip -DestinationPath . -Force
+Set-Location "elastic-agent-$AgentVersion-windows-x86_64"
+
+# Install and enroll the agent non-interactively
+Start-Process .\elastic-agent.exe -ArgumentList @(
+    'install',
+    '--url', $FleetUrl,
+    '--enrollment-token', $EnrollmentToken,
+    '--insecure',
+    '-b'
+) -Wait -NoNewWindow


### PR DESCRIPTION
## Summary
- add script to install and enroll Elastic Agent on Linux
- add PowerShell script to install and enroll Elastic Agent on Windows
- document installer usage

## Testing
- `bash -n scripts/install-agent-linux.sh`
- `shellcheck scripts/install-agent-linux.sh` *(fails: command not found)*
- `pwsh -NoLogo -Command "Get-Command"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ad431a748333a5d0a017504bbc0a