### PR TITLE
fix: set kibana to use elasticsearch password

### DIFF
--- a/configs/kibana/kibana.yml
+++ b/configs/kibana/kibana.yml
@@ -4,7 +4,7 @@ server.publicBaseUrl: ${SERVER_PUBLICBASEURL:http://localhost:5601}
 # Verbindung zu ES (hier via Superuser – für Produktion separat absichern!)
 elasticsearch.hosts: ["http://es01:9200"]
 elasticsearch.username: ${ELASTICSEARCH_USERNAME:elastic}
-elasticsearch.password: ${ELASTIC_PASSWORD}
+elasticsearch.password: ${ELASTICSEARCH_PASSWORD}
 
 # File-Logging aktivieren (statt nur stdout)
 logging:


### PR DESCRIPTION
## Summary
- point Kibana to ELASTICSEARCH_PASSWORD so config doesn't reference undefined ELASTIC_PASSWORD

## Testing
- `docker compose config` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b6c8f7e34483339f5b9039c087299f