### PR TITLE
Remove deprecated xpack.security flag from Kibana config

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -253,7 +253,6 @@ logging:
     level: info
     appenders: [file]
 
-xpack.security.enabled: true
 ```
 
 ---

--- a/configs/kibana/kibana.yml
+++ b/configs/kibana/kibana.yml
@@ -17,5 +17,3 @@ logging:
   root:
     level: info
     appenders: [file]
-
-xpack.security.enabled: true


### PR DESCRIPTION
## Summary
- drop xpack.security.enabled from Kibana config since the key was removed in Kibana 8.16
- update docs to reflect the new configuration

## Testing
- `python - <<'PY'
import yaml, sys
for path in ['configs/kibana/kibana.yml', 'configs/elasticsearch/elasticsearch.yml']:
    with open(path) as f:
        yaml.safe_load(f)
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b6cbef88948333862db1af27848a23