### PR TITLE
Automate Kibana startup with service account token

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,6 @@ ELASTIC_PASSWORD=ChangeMe_please_!2025
 
 # JVM & Ressourcen
 ES_JAVA_OPTS=-Xms1g -Xmx1g
+
+# Wird beim Start automatisch gesetzt
+KIBANA_SERVICE_TOKEN=

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Dieses Repository enthält ein Docker-Compose-Setup für einen einzelnen Elastic
 # Provisionierung (Docker & Kernel-Tuning)
 sudo bash scripts/provision.sh
 
-# Stack starten
-docker compose up -d
+# Stack starten (Elasticsearch + Token + Kibana + Fleet)
+bash scripts/start.sh
 ```
 
 Danach stehen die Dienste unter den folgenden Ports zur Verfügung:

--- a/configs/kibana/kibana.yml
+++ b/configs/kibana/kibana.yml
@@ -1,10 +1,9 @@
 server.host: 0.0.0.0
 server.publicBaseUrl: ${SERVER_PUBLICBASEURL:http://localhost:5601}
 
-# Verbindung zu ES (hier via Superuser – für Produktion separat absichern!)
+# Verbindung zu ES über Service-Account-Token
 elasticsearch.hosts: ["http://es01:9200"]
-elasticsearch.username: ${ELASTICSEARCH_USERNAME:elastic}
-elasticsearch.password: ${ELASTICSEARCH_PASSWORD}
+elasticsearch.serviceAccountToken: ${ELASTICSEARCH_SERVICEACCOUNTTOKEN}
 
 # File-Logging aktivieren (statt nur stdout)
 logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,10 +49,8 @@ services:
     depends_on:
       - es01
     environment:
-      # Fürs Bootstrapping verwenden wir den elastic-User
       - ELASTICSEARCH_HOSTS=http://es01:9200
-      - ELASTICSEARCH_USERNAME=elastic
-      - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD}
+      - ELASTICSEARCH_SERVICEACCOUNTTOKEN=${KIBANA_SERVICE_TOKEN}
       # Optional: öffentlich erreichbare Basis-URL (für Links)
       - SERVER_PUBLICBASEURL=${KIBANA_PUBLIC_URL:-http://localhost:5601}
     ports:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Always execute from repository root
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Load environment variables
+source .env
+
+echo "[1/3] Start Elasticsearch"
+docker compose up -d es01
+
+echo "[2/3] Waiting for Elasticsearch to respond"
+until curl -s -u elastic:"$ELASTIC_PASSWORD" http://localhost:9200 >/dev/null 2>&1; do
+  sleep 2
+done
+
+echo "[3/3] Create Kibana service account token"
+TOKEN=$(docker exec es01 bin/elasticsearch-service-tokens create elastic/kibana kibana | tail -n 1)
+
+if grep -q '^KIBANA_SERVICE_TOKEN=' .env; then
+  sed -i "s/^KIBANA_SERVICE_TOKEN=.*/KIBANA_SERVICE_TOKEN=$TOKEN/" .env
+else
+  echo "KIBANA_SERVICE_TOKEN=$TOKEN" >> .env
+fi
+
+export KIBANA_SERVICE_TOKEN="$TOKEN"
+docker compose up -d
+
+echo "Stack is running. Kibana service token stored in .env"
+


### PR DESCRIPTION
## Summary
- replace Kibana credentials with service account token
- add startup script to create token and bring up the full stack
- document automated startup in README

## Testing
- `bash -n scripts/start.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cd1cd27c8333a998571d8a64df66