### PR TITLE
Fix fleet-server data volume to avoid missing elastic-agent binary

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -192,7 +192,8 @@ services:
       - "8220:8220"
     volumes:
       # Persistente Agent-/Fleet-Server-Daten & -Logs
-      - /mnt/elastic_logs/fleet-server/agent:/usr/share/elastic-agent
+      # Nur das Datenverzeichnis mounten, damit die Binärdateien des Elastic Agents im Container verbleiben
+      - /mnt/elastic_logs/fleet-server/agent:/usr/share/elastic-agent/data
       - /mnt/elastic_logs/fleet-server/logs:/var/log/elastic-agent
     networks:
       - elk-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,8 @@ services:
       - "8220:8220"
     volumes:
       # Persistente Agent-/Fleet-Server-Daten & -Logs
-      - /mnt/elastic_logs/fleet-server/agent:/usr/share/elastic-agent
+      # Nur das Datenverzeichnis mounten, damit die Binärdateien des Elastic Agents im Container verbleiben
+      - /mnt/elastic_logs/fleet-server/agent:/usr/share/elastic-agent/data
       - /mnt/elastic_logs/fleet-server/logs:/var/log/elastic-agent
     networks:
       - elk-net


### PR DESCRIPTION
## Summary
- mount only `/usr/share/elastic-agent/data` for Fleet Server so the elastic-agent binary is not hidden by the host bind
- document the adjusted Fleet Server volume mapping in `agents.md`

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cfe6ffe4833384840db337accc68