### PR TITLE
Quote ES_JAVA_OPTS to prevent source error

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ STACK_VERSION=8.16.3
 ELASTIC_PASSWORD=ChangeMe_please_!2025
 
 # JVM & Ressourcen
-ES_JAVA_OPTS=-Xms1g -Xmx1g
+ES_JAVA_OPTS="-Xms1g -Xmx1g"
 
 # Wird beim Start automatisch gesetzt
 KIBANA_SERVICE_TOKEN=


### PR DESCRIPTION
## Summary
- Quote the ES_JAVA_OPTS assignment so start.sh can source .env without running stray commands.

## Testing
- `bash scripts/start.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d0ddb4cc8333b1dce17cdf98278d