### PR TITLE
Clarify fleet-server data mount and drop compose version

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -101,8 +101,6 @@ ES_JAVA_OPTS=-Xms1g -Xmx1g
 ### 2) `docker-compose.yml`
 
 ```yaml
-version: "3.9"
-
 name: elk-stack
 
 networks:
@@ -192,7 +190,8 @@ services:
       - "8220:8220"
     volumes:
       # Persistente Agent-/Fleet-Server-Daten & -Logs
-      # Nur das Datenverzeichnis mounten, damit die Binärdateien des Elastic Agents im Container verbleiben
+      # Wichtig: Nur das Datenverzeichnis mounten – ein Bind auf /usr/share/elastic-agent
+      # würde das Agent-Binary überschreiben und der Container könnte nicht starten.
       - /mnt/elastic_logs/fleet-server/agent:/usr/share/elastic-agent/data
       - /mnt/elastic_logs/fleet-server/logs:/var/log/elastic-agent
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 name: elk-stack
 
 networks:
@@ -87,7 +85,8 @@ services:
       - "8220:8220"
     volumes:
       # Persistente Agent-/Fleet-Server-Daten & -Logs
-      # Nur das Datenverzeichnis mounten, damit die Binärdateien des Elastic Agents im Container verbleiben
+      # Wichtig: Nur das Datenverzeichnis mounten – ein Bind auf /usr/share/elastic-agent
+      # würde das Agent-Binary überschreiben und der Container könnte nicht starten.
       - /mnt/elastic_logs/fleet-server/agent:/usr/share/elastic-agent/data
       - /mnt/elastic_logs/fleet-server/logs:/var/log/elastic-agent
     networks:


### PR DESCRIPTION
## Summary
- remove deprecated compose version header
- clarify fleet-server volume mounts so the elastic-agent binary isn't hidden

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fa9a1c90833384d55b19b44d1622