### PR TITLE
Add TLS with self-signed certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,23 @@ Dieses Repository enthält ein Docker-Compose-Setup für einen einzelnen Elastic
 # Provisionierung (Docker & Kernel-Tuning)
 sudo bash scripts/provision.sh
 
+# Selbstsignierte Zertifikate erzeugen
+bash scripts/generate-certs.sh
+
 # Stack starten (Elasticsearch + Token + Kibana + Fleet)
 bash scripts/start.sh
 ```
 
-Danach stehen die Dienste unter den folgenden Ports zur Verfügung:
+Danach stehen die Dienste verschlüsselt unter den folgenden Ports zur Verfügung:
 
-- Elasticsearch: http://localhost:9200
-- Kibana: http://localhost:5601
-- Fleet Server: http://localhost:8220
+- Elasticsearch: https://localhost:9200
+- Kibana: https://localhost:5601
+- Fleet Server: https://localhost:8220
 
 Für eine erste Überprüfung:
 
 ```bash
-curl -s -u elastic:$ELASTIC_PASSWORD http://localhost:9200 | jq .
+curl -s --cacert certs/ca.crt -u elastic:$ELASTIC_PASSWORD https://localhost:9200 | jq .
 ```
 
 Das `start.sh`-Skript entfernt vor dem Start automatisch einen eventuell

--- a/certs/.gitignore
+++ b/certs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/configs/elasticsearch/elasticsearch.yml
+++ b/configs/elasticsearch/elasticsearch.yml
@@ -5,12 +5,19 @@ discovery.type: single-node
 # Logging-Tuning (optional)
 logger.level: info
 
-# Achtung: Dieses Setup nutzt HTTP ohne TLS (nur Dev!)
+# Sicherheit aktivieren und TLS für HTTP/Transport einschalten
 xpack.security.enabled: true
 xpack.security.http.ssl:
-  enabled: false
+  enabled: true
+  certificate: /usr/share/elasticsearch/config/certs/es01.crt
+  key: /usr/share/elasticsearch/config/certs/es01.key
+  certificate_authorities: ["/usr/share/elasticsearch/config/certs/ca.crt"]
 xpack.security.transport.ssl:
-  enabled: false
+  enabled: true
+  verification_mode: certificate
+  certificate: /usr/share/elasticsearch/config/certs/es01.crt
+  key: /usr/share/elasticsearch/config/certs/es01.key
+  certificate_authorities: ["/usr/share/elasticsearch/config/certs/ca.crt"]
 
 path:
   data: /usr/share/elasticsearch/data

--- a/configs/kibana/kibana.yml
+++ b/configs/kibana/kibana.yml
@@ -1,9 +1,14 @@
 server.host: 0.0.0.0
-server.publicBaseUrl: ${SERVER_PUBLICBASEURL:http://localhost:5601}
+server.publicBaseUrl: ${SERVER_PUBLICBASEURL:https://localhost:5601}
+server.ssl.enabled: true
+server.ssl.certificate: /usr/share/kibana/config/certs/kibana.crt
+server.ssl.key: /usr/share/kibana/config/certs/kibana.key
 
 # Verbindung zu ES über Service-Account-Token
-elasticsearch.hosts: ["http://es01:9200"]
+elasticsearch.hosts: ["https://es01:9200"]
 elasticsearch.serviceAccountToken: ${ELASTICSEARCH_SERVICEACCOUNTTOKEN}
+elasticsearch.ssl.certificateAuthorities: ["/usr/share/kibana/config/certs/ca.crt"]
+elasticsearch.ssl.verificationMode: certificate
 
 # File-Logging aktivieren (statt nur stdout)
 logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,8 @@ services:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - ES_JAVA_OPTS=${ES_JAVA_OPTS}
-      # Security an, HTTP ohne TLS (dev)
+      # Security an, TLS aktiviert
       - xpack.security.enabled=true
-      - xpack.security.http.ssl.enabled=false
-      - xpack.security.transport.ssl.enabled=false
       # Logs in Datei (wird gemountet)
       - path.logs=/usr/share/elasticsearch/logs
       # Benutzerpasswort (Superuser)
@@ -37,6 +35,7 @@ services:
       - /mnt/elastic_logs/elasticsearch/data:/usr/share/elasticsearch/data
       - /mnt/elastic_logs/elasticsearch/logs:/usr/share/elasticsearch/logs
       - ./configs/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+      - ./certs:/usr/share/elasticsearch/config/certs:ro
     networks:
       - elk-net
 
@@ -47,15 +46,16 @@ services:
     depends_on:
       - es01
     environment:
-      - ELASTICSEARCH_HOSTS=http://es01:9200
+      - ELASTICSEARCH_HOSTS=https://es01:9200
       - ELASTICSEARCH_SERVICEACCOUNTTOKEN=${KIBANA_SERVICE_TOKEN}
       # Optional: öffentlich erreichbare Basis-URL (für Links)
-      - SERVER_PUBLICBASEURL=${KIBANA_PUBLIC_URL:-http://localhost:5601}
+      - SERVER_PUBLICBASEURL=${KIBANA_PUBLIC_URL:-https://localhost:5601}
     ports:
       - "5601:5601"
     volumes:
       - ./configs/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
       - /mnt/elastic_logs/kibana/logs:/usr/share/kibana/logs
+      - ./certs:/usr/share/kibana/config/certs:ro
     networks:
       - elk-net
 
@@ -67,19 +67,21 @@ services:
       - es01
       - kibana
     environment:
-      # Fleet Server aktivieren & an ES/Kibana koppeln (HTTP, ohne TLS)
+      # Fleet Server mit TLS an ES/Kibana koppeln
       - FLEET_SERVER_ENABLE=1
-      - FLEET_SERVER_ELASTICSEARCH_HOST=http://es01:9200
-      - FLEET_SERVER_INSECURE_HTTP=true
-      # (Ab neueren Releases erledigt Kibana die Fleet-Initialisierung selbst.
-      #  KIBANA_FLEET_SETUP kann i.d.R. entfallen.)
-      - KIBANA_HOST=http://kibana:5601
+      - FLEET_SERVER_ELASTICSEARCH_HOST=https://es01:9200
+      - FLEET_SERVER_ELASTICSEARCH_CA=/usr/share/elastic-agent/certs/ca.crt
+      - FLEET_SERVER_CERT=/usr/share/elastic-agent/certs/fleet-server.crt
+      - FLEET_SERVER_CERT_KEY=/usr/share/elastic-agent/certs/fleet-server.key
+      - KIBANA_HOST=https://kibana:5601
+      - KIBANA_CA=/usr/share/elastic-agent/certs/ca.crt
       - KIBANA_USERNAME=elastic
       - KIBANA_PASSWORD=${ELASTIC_PASSWORD}
       # Gemeinsame ES-Creds (werden auch vom Agent genutzt)
-      - ELASTICSEARCH_HOST=http://es01:9200
+      - ELASTICSEARCH_HOST=https://es01:9200
       - ELASTICSEARCH_USERNAME=elastic
       - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD}
+      - ELASTICSEARCH_CA=/usr/share/elastic-agent/certs/ca.crt
       - LOG_LEVEL=info
     ports:
       - "8220:8220"
@@ -89,5 +91,6 @@ services:
       # würde das Agent-Binary überschreiben und der Container könnte nicht starten.
       - /mnt/elastic_logs/fleet-server/agent:/usr/share/elastic-agent/data
       - /mnt/elastic_logs/fleet-server/logs:/var/log/elastic-agent
+      - ./certs:/usr/share/elastic-agent/certs:ro
     networks:
       - elk-net

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CERT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../certs" && pwd)"
+mkdir -p "$CERT_DIR"
+
+# Generate Certificate Authority if not existing
+if [[ ! -f "$CERT_DIR/ca.crt" ]]; then
+  openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+    -keyout "$CERT_DIR/ca.key" -out "$CERT_DIR/ca.crt" \
+    -subj "/CN=elk-stack-ca"
+fi
+
+generate_cert() {
+  local name="$1"
+  openssl req -newkey rsa:4096 -nodes \
+    -keyout "$CERT_DIR/${name}.key" -out "$CERT_DIR/${name}.csr" \
+    -subj "/CN=${name}" -addext "subjectAltName=DNS:${name}"
+  openssl x509 -req -in "$CERT_DIR/${name}.csr" -CA "$CERT_DIR/ca.crt" \
+    -CAkey "$CERT_DIR/ca.key" -CAcreateserial \
+    -out "$CERT_DIR/${name}.crt" -days 365 -sha256
+  rm "$CERT_DIR/${name}.csr"
+}
+
+generate_cert es01
+generate_cert kibana
+generate_cert fleet-server
+
+rm -f "$CERT_DIR/ca.srl"
+
+echo "Certificates written to $CERT_DIR"

--- a/scripts/install-agent-linux.sh
+++ b/scripts/install-agent-linux.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Root directory of the repository
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 # Elastic Agent version to install. Defaults to STACK_VERSION from .env or 8.16.3.
 AGENT_VERSION="${AGENT_VERSION:-${STACK_VERSION:-8.16.3}}"
-FLEET_URL="${FLEET_URL:-http://localhost:8220}"
+FLEET_URL="${FLEET_URL:-https://localhost:8220}"
 
 if [[ -z "${ENROLLMENT_TOKEN:-}" ]]; then
   echo "ENROLLMENT_TOKEN environment variable must be set" >&2
@@ -22,5 +25,5 @@ cd "elastic-agent-${AGENT_VERSION}-linux-x86_64"
 sudo ./elastic-agent install \
   --url "$FLEET_URL" \
   --enrollment-token "$ENROLLMENT_TOKEN" \
-  --insecure \
+  --certificate-authorities "$REPO_ROOT/certs/ca.crt" \
   -b

--- a/scripts/install-agent-windows.ps1
+++ b/scripts/install-agent-windows.ps1
@@ -13,7 +13,7 @@ if (-not $AgentVersion) {
 }
 
 if (-not $FleetUrl) {
-    $FleetUrl = 'http://localhost:8220'
+    $FleetUrl = 'https://localhost:8220'
 }
 
 $Zip = "elastic-agent-$AgentVersion-windows-x86_64.zip"
@@ -28,6 +28,6 @@ Start-Process .\elastic-agent.exe -ArgumentList @(
     'install',
     '--url', $FleetUrl,
     '--enrollment-token', $EnrollmentToken,
-    '--insecure',
+    '--certificate-authorities', '..\certs\ca.crt',
     '-b'
 ) -Wait -NoNewWindow

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -26,7 +26,7 @@ echo "[1/3] Start Elasticsearch"
 docker compose up -d es01
 
 echo "[2/3] Waiting for Elasticsearch to respond"
-until curl -s -u elastic:"$ELASTIC_PASSWORD" http://localhost:9200 >/dev/null 2>&1; do
+until curl -s --cacert certs/ca.crt -u elastic:"$ELASTIC_PASSWORD" https://localhost:9200 >/dev/null 2>&1; do
   sleep 2
 done
 


### PR DESCRIPTION
## Summary
- add script to generate self-signed CA and certs for Elasticsearch, Kibana and Fleet Server
- enable TLS across services and update start/agent install scripts
- document HTTPS usage in README

## Testing
- `bash scripts/generate-certs.sh`
- `bash -n scripts/generate-certs.sh scripts/start.sh scripts/install-agent-linux.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83f8d661083338fc215c6207242a3