### PR TITLE
fix: ensure cert files readable before starting stack

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -19,8 +19,15 @@ grep -Ev '^KIBANA_SERVICE_TOKEN=' "${ENV_FILE}" | \
 mv "${ENV_FILE}.tmp" "${ENV_FILE}"
 
 set -a
-source "${ENV_FILE}"
+ # shellcheck source=/dev/null
+ source "${ENV_FILE}"
 set +a
+
+# Ensure certificate files are readable inside the container
+if [[ -d certs ]]; then
+  find certs -type f -name '*.key' -exec chown root:root {} \; -exec chmod 660 {} \;
+  find certs -type f -name '*.crt' -exec chown root:root {} \; -exec chmod 644 {} \;
+fi
 
 echo "[1/3] Start Elasticsearch"
 docker compose up -d es01


### PR DESCRIPTION
## Summary
- make start.sh adjust certificate file ownership and permissions so Elasticsearch can read keys when volumes are mounted read-only

## Testing
- `shellcheck scripts/start.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b846f5a5f883338e2438f04dbfb2ba