### PR TITLE
Fix Elasticsearch hostname check for local startup

### DIFF
--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -13,16 +13,18 @@ fi
 
 generate_cert() {
   local name="$1"
+  local san="${2:-DNS:${name}}"
   openssl req -newkey rsa:4096 -nodes \
     -keyout "$CERT_DIR/${name}.key" -out "$CERT_DIR/${name}.csr" \
-    -subj "/CN=${name}" -addext "subjectAltName=DNS:${name}"
+    -subj "/CN=${name}" -addext "subjectAltName=${san}"
   openssl x509 -req -in "$CERT_DIR/${name}.csr" -CA "$CERT_DIR/ca.crt" \
     -CAkey "$CERT_DIR/ca.key" -CAcreateserial \
     -out "$CERT_DIR/${name}.crt" -days 365 -sha256
   rm "$CERT_DIR/${name}.csr"
 }
 
-generate_cert es01
+# Include localhost as an additional Subject Alternative Name for Elasticsearch
+generate_cert es01 "DNS:es01,DNS:localhost"
 generate_cert kibana
 generate_cert fleet-server
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -33,7 +33,8 @@ echo "[1/3] Start Elasticsearch"
 docker compose up -d es01
 
 echo "[2/3] Waiting for Elasticsearch to respond"
-until curl -s --cacert certs/ca.crt -u elastic:"$ELASTIC_PASSWORD" https://localhost:9200 >/dev/null 2>&1; do
+until curl -s --cacert certs/ca.crt --resolve es01:9200:127.0.0.1 \
+    -u elastic:"$ELASTIC_PASSWORD" https://es01:9200 >/dev/null 2>&1; do
   sleep 2
 done
 


### PR DESCRIPTION
## Summary
- allow cert generator to add extra SANs and include `localhost` for Elasticsearch
- wait for Elasticsearch using `es01` hostname to avoid SAN mismatch

## Testing
- `bash scripts/generate-certs.sh`
- `bash scripts/start.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8498203b88333bd4e7e635b2d974e