### PR TITLE
Add Caddy reverse proxy to route stack traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ bash scripts/generate-certs.sh
 bash scripts/start.sh
 ```
 
-Danach stehen die Dienste verschlüsselt unter den folgenden Ports zur Verfügung:
+Danach stehen die Dienste verschlüsselt über Caddy zur Verfügung:
 
-- Elasticsearch: https://localhost:9200
-- Kibana: https://localhost:5601
-- Fleet Server: https://localhost:8220
+- Elasticsearch: https://es.local
+- Kibana: https://kibana.local
+- Fleet Server: https://fleet.local
 
 Für eine erste Überprüfung:
 
 ```bash
-curl -s --cacert certs/ca.crt -u elastic:$ELASTIC_PASSWORD https://localhost:9200 | jq .
+curl -s --cacert certs/ca.crt -u elastic:$ELASTIC_PASSWORD https://es.local | jq .
 ```
 
 Das `start.sh`-Skript entfernt vor dem Start automatisch einen eventuell

--- a/configs/caddy/Caddyfile
+++ b/configs/caddy/Caddyfile
@@ -1,0 +1,35 @@
+es.local {
+    tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
+    reverse_proxy https://es01:9200 {
+        transport http {
+            tls {
+                ca_cert /etc/caddy/certs/ca.crt
+            }
+        }
+        header_up Host es01
+    }
+}
+
+kibana.local {
+    tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
+    reverse_proxy https://kibana:5601 {
+        transport http {
+            tls {
+                ca_cert /etc/caddy/certs/ca.crt
+            }
+        }
+        header_up Host kibana
+    }
+}
+
+fleet.local {
+    tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
+    reverse_proxy https://fleet-server:8220 {
+        transport http {
+            tls {
+                ca_cert /etc/caddy/certs/ca.crt
+            }
+        }
+        header_up Host fleet-server
+    }
+}

--- a/configs/kibana/kibana.yml
+++ b/configs/kibana/kibana.yml
@@ -1,5 +1,5 @@
 server.host: 0.0.0.0
-server.publicBaseUrl: ${SERVER_PUBLICBASEURL:https://localhost:5601}
+server.publicBaseUrl: ${SERVER_PUBLICBASEURL:https://kibana.local}
 server.ssl.enabled: true
 server.ssl.certificate: /usr/share/kibana/config/certs/kibana.crt
 server.ssl.key: /usr/share/kibana/config/certs/kibana.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,6 @@ services:
       nofile:
         soft: 65536
         hard: 65536
-    ports:
-      - "9200:9200"
-      - "9300:9300"
     volumes:
       - /mnt/elastic_logs/elasticsearch/data:/usr/share/elasticsearch/data
       - /mnt/elastic_logs/elasticsearch/logs:/usr/share/elasticsearch/logs
@@ -49,9 +46,7 @@ services:
       - ELASTICSEARCH_HOSTS=https://es01:9200
       - ELASTICSEARCH_SERVICEACCOUNTTOKEN=${KIBANA_SERVICE_TOKEN}
       # Optional: öffentlich erreichbare Basis-URL (für Links)
-      - SERVER_PUBLICBASEURL=${KIBANA_PUBLIC_URL:-https://localhost:5601}
-    ports:
-      - "5601:5601"
+      - SERVER_PUBLICBASEURL=${KIBANA_PUBLIC_URL:-https://kibana.local}
     volumes:
       - ./configs/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
       - /mnt/elastic_logs/kibana/logs:/usr/share/kibana/logs
@@ -83,8 +78,6 @@ services:
       - ELASTICSEARCH_PASSWORD=${ELASTIC_PASSWORD}
       - ELASTICSEARCH_CA=/usr/share/elastic-agent/certs/ca.crt
       - LOG_LEVEL=info
-    ports:
-      - "8220:8220"
     volumes:
       # Persistente Agent-/Fleet-Server-Daten & -Logs
       # Wichtig: Nur das Datenverzeichnis mounten – ein Bind auf /usr/share/elastic-agent
@@ -92,5 +85,22 @@ services:
       - /mnt/elastic_logs/fleet-server/agent:/usr/share/elastic-agent/data
       - /mnt/elastic_logs/fleet-server/logs:/var/log/elastic-agent
       - ./certs:/usr/share/elastic-agent/certs:ro
+    networks:
+      - elk-net
+
+  caddy:
+    image: caddy:2
+    container_name: caddy
+    restart: unless-stopped
+    depends_on:
+      - es01
+      - kibana
+      - fleet-server
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./configs/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./certs:/etc/caddy/certs:ro
     networks:
       - elk-net

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -27,6 +27,7 @@ generate_cert() {
 generate_cert es01 "DNS:es01,DNS:localhost"
 generate_cert kibana
 generate_cert fleet-server
+generate_cert caddy "DNS:es.local,DNS:kibana.local,DNS:fleet.local"
 
 rm -f "$CERT_DIR/ca.srl"
 

--- a/scripts/install-agent-linux.sh
+++ b/scripts/install-agent-linux.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Elastic Agent version to install. Defaults to STACK_VERSION from .env or 8.16.3.
 AGENT_VERSION="${AGENT_VERSION:-${STACK_VERSION:-8.16.3}}"
-FLEET_URL="${FLEET_URL:-https://localhost:8220}"
+FLEET_URL="${FLEET_URL:-https://fleet.local}"
 
 if [[ -z "${ENROLLMENT_TOKEN:-}" ]]; then
   echo "ENROLLMENT_TOKEN environment variable must be set" >&2

--- a/scripts/install-agent-windows.ps1
+++ b/scripts/install-agent-windows.ps1
@@ -13,7 +13,7 @@ if (-not $AgentVersion) {
 }
 
 if (-not $FleetUrl) {
-    $FleetUrl = 'https://localhost:8220'
+    $FleetUrl = 'https://fleet.local'
 }
 
 $Zip = "elastic-agent-$AgentVersion-windows-x86_64.zip"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -33,8 +33,8 @@ echo "[1/3] Start Elasticsearch"
 docker compose up -d es01
 
 echo "[2/3] Waiting for Elasticsearch to respond"
-until curl -s --cacert certs/ca.crt --resolve es01:9200:127.0.0.1 \
-    -u elastic:"$ELASTIC_PASSWORD" https://es01:9200 >/dev/null 2>&1; do
+until docker exec es01 curl -s --cacert /usr/share/elasticsearch/config/certs/ca.crt \
+    -u elastic:"$ELASTIC_PASSWORD" https://localhost:9200 >/dev/null 2>&1; do
   sleep 2
 done
 


### PR DESCRIPTION
## Summary
- add Caddy service and config to terminate TLS for Elasticsearch, Kibana, and Fleet Server
- update compose file, cert generation, and start/install scripts to use Caddy endpoints
- document new HTTPS hosts and usage

## Testing
- `bash scripts/generate-certs.sh`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84e96a560833383380337ef66cc85