### PR TITLE
Start Caddy earlier for initial checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,6 @@ services:
     restart: unless-stopped
     depends_on:
       - es01
-      - kibana
-      - fleet-server
     ports:
       - "80:80"
       - "443:443"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -29,8 +29,8 @@ if [[ -d certs ]]; then
   find certs -type f -name '*.crt' -exec chown root:root {} \; -exec chmod 644 {} \;
 fi
 
-echo "[1/3] Start Elasticsearch"
-docker compose up -d es01
+echo "[1/3] Start Elasticsearch and Caddy"
+docker compose up -d es01 caddy
 
 echo "[2/3] Waiting for Elasticsearch to respond"
 until docker exec es01 curl -s --cacert /usr/share/elasticsearch/config/certs/ca.crt \


### PR DESCRIPTION
## Summary
- Ensure Caddy starts alongside Elasticsearch for early health checks
- Drop unnecessary dependencies on Kibana and Fleet Server in docker compose

## Testing
- ⚠️ `docker compose config` *(command failed: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b85388059c833394d9543f890dddaf