### PR TITLE
Fix literal brace handling in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -111,7 +111,8 @@ pairs = list(zip(args[::2], args[1::2]))
 content = path.read_text()
 for old, new in pairs:
     pattern = re.compile(rf'(?m)^{re.escape(old)}\s*{')
-    content = pattern.sub(f"{new} {{", content, count=1)
+    replacement = f"{new} " + "{"
+    content = pattern.sub(replacement, content, count=1)
 path.write_text(content)
 PYTHON
 }


### PR DESCRIPTION
## Summary
- build the replacement string for the Caddy host entries without relying on an escaped brace in an f-string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb0c43c0048333ae818b7373ae1ef1