### PR TITLE
Add Elastic licensing notice to MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+MIT License
+
+Copyright (c) 2024 Mythos Machina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Additional Notice:
+This project is an installer/wrapper which references and downloads official
+Elasticsearch, Kibana, and Logstash distributions. These components are not
+licensed under MIT. They are provided under the Elastic License 2.0 or Apache
+2.0 (depending on version). For details, see:
+https://www.elastic.co/licensing/elastic-license


### PR DESCRIPTION
## Summary
- append an additional notice to the MIT license clarifying Elastic component licensing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb10eae6b883338d8ee33dde3ef3b2