### PR TITLE
Fix caddy reverse proxy backend definitions

### DIFF
--- a/configs/caddy/Caddyfile
+++ b/configs/caddy/Caddyfile
@@ -1,6 +1,6 @@
 es.local {
     tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
-    reverse_proxy https://es01:9200 {
+    reverse_proxy es01:9200 {
         transport http {
             tls {
                 ca_cert /etc/caddy/certs/ca.crt
@@ -12,7 +12,7 @@ es.local {
 
 kibana.local {
     tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
-    reverse_proxy https://kibana:5601 {
+    reverse_proxy kibana:5601 {
         transport http {
             tls {
                 ca_cert /etc/caddy/certs/ca.crt
@@ -24,7 +24,7 @@ kibana.local {
 
 fleet.local {
     tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
-    reverse_proxy https://fleet-server:8220 {
+    reverse_proxy fleet-server:8220 {
         transport http {
             tls {
                 ca_cert /etc/caddy/certs/ca.crt


### PR DESCRIPTION
## Summary
- update caddy reverse proxy upstream definitions to avoid subdirective parsing errors
- keep TLS transport customization for Elasticsearch, Kibana, and Fleet backends

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cbd103064c833397273bb932ca8130