### PR TITLE
Fix caddy reverse proxy blocks

### DIFF
--- a/configs/caddy/Caddyfile
+++ b/configs/caddy/Caddyfile
@@ -1,6 +1,7 @@
 es.local {
     tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
-    reverse_proxy es01:9200 {
+    reverse_proxy {
+        to https://es01:9200
         transport http {
             tls {
                 ca_cert /etc/caddy/certs/ca.crt
@@ -12,7 +13,8 @@ es.local {
 
 kibana.local {
     tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
-    reverse_proxy kibana:5601 {
+    reverse_proxy {
+        to https://kibana:5601
         transport http {
             tls {
                 ca_cert /etc/caddy/certs/ca.crt
@@ -24,7 +26,8 @@ kibana.local {
 
 fleet.local {
     tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
-    reverse_proxy fleet-server:8220 {
+    reverse_proxy {
+        to https://fleet-server:8220
         transport http {
             tls {
                 ca_cert /etc/caddy/certs/ca.crt


### PR DESCRIPTION
## Summary
- update the Caddy reverse proxy blocks to use the block-style syntax
- explicitly configure upstreams with https scheme while preserving the custom HTTP transport with the Fleet CA

## Testing
- docker compose config *(fails: docker not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd5adf708833383e765dc9d04ea6c