### PR TITLE
Fix Caddyfile reverse proxy syntax

### DIFF
--- a/configs/caddy/Caddyfile
+++ b/configs/caddy/Caddyfile
@@ -1,38 +1,29 @@
 es.local {
     tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
-    reverse_proxy {
-        to https://es01:9200
-        transport http {
-            tls {
-                ca_cert /etc/caddy/certs/ca.crt
-            }
-        }
+    reverse_proxy https://es01:9200 {
         header_up Host es01
+        transport http {
+            tls_trust_pool /etc/caddy/certs/ca.crt
+        }
     }
 }
 
 kibana.local {
     tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
-    reverse_proxy {
-        to https://kibana:5601
-        transport http {
-            tls {
-                ca_cert /etc/caddy/certs/ca.crt
-            }
-        }
+    reverse_proxy https://kibana:5601 {
         header_up Host kibana
+        transport http {
+            tls_trust_pool /etc/caddy/certs/ca.crt
+        }
     }
 }
 
 fleet.local {
     tls /etc/caddy/certs/caddy.crt /etc/caddy/certs/caddy.key
-    reverse_proxy {
-        to https://fleet-server:8220
-        transport http {
-            tls {
-                ca_cert /etc/caddy/certs/ca.crt
-            }
-        }
+    reverse_proxy https://fleet-server:8220 {
         header_up Host fleet-server
+        transport http {
+            tls_trust_pool /etc/caddy/certs/ca.crt
+        }
     }
 }


### PR DESCRIPTION
## Summary
- adopt the working production-style reverse_proxy syntax for all services in the Caddyfile
- ensure host headers continue to be forwarded while using the tls_trust_pool directive for upstream TLS

## Testing
- caddy validate --adapter caddyfile --config configs/caddy/Caddyfile *(fails: `caddy` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe4e3e9308333b43bd9f6bc33e528