### PR TITLE
feat: enhance certificate generation

### DIFF
--- a/ChangeLog/2025-09-18-cf4f446.md
+++ b/ChangeLog/2025-09-18-cf4f446.md
@@ -1,0 +1,12 @@
+# Änderungsbericht zu Commit cf4f446
+
+## Zusammenfassung
+- Zertifikatsskript erweitert: Domains aus `.env`, Container-Hostnamen und `localhost` werden konsolidiert als SAN-Einträge übernommen.
+- Sicherheitsabfrage ergänzt, die auf vorhandene Zertifikate reagiert und bei Bedarf vollständige Neuerstellung inklusive CA ermöglicht.
+- README aktualisiert, um die erweiterten Fähigkeiten und das Schutzverhalten des Skripts transparent zu dokumentieren.
+
+## Details
+- Hostnamen werden über eine deduplizierende Hilfsfunktion sortiert, bevor sie als `subjectAltName` an OpenSSL übergeben werden; dabei werden Ports entfernt und optionale Fleet-URLs berücksichtigt.
+- Die Zertifikatserstellung nutzt jetzt `-copy_extensions copy`, damit die SAN-Einträge aus der CSR in das signierte Zertifikat übernommen werden.
+- Die Benutzerführung informiert über bestehende Zertifikate, entfernt diese bei Bestätigung vollständig und vermeidet unerwünschtes Überschreiben.
+- Dokumentation beschreibt die automatische Einbindung der Service-Namen (`es01`, `kibana`, `fleet-server`, `caddy`) und den Sicherheitsdialog zur Wiederverwendung.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Dieses Repository liefert ein vorkonfiguriertes Docker-Compose-Stack für einen 
 | ✅ Feature | Beschreibung |
 | --- | --- |
 | **One-Command-Provisioning** | `scripts/provision.sh` kümmert sich um Docker, Kernel-Tuning (`vm.max_map_count`) und Verzeichnisstruktur. |
-| **Automatisierte Zertifikate** | `scripts/generate-certs.sh` erzeugt eine lokale CA inklusive Service-Zertifikate für `es.local`, `kibana.local` und `fleet.local`. |
+| **Automatisierte Zertifikate** | `scripts/generate-certs.sh` erzeugt eine lokale CA, übernimmt Domains aus `.env` sowie Container-Hostnamen in die SAN-Liste und warnt vor Überschreibungen bestehender Zertifikate. |
 | **Sicherer Fleet-Start** | `scripts/start.sh` startet Elasticsearch & Caddy, erstellt ein frisches Kibana-Service-Token und bringt Fleet/Kibana danach online. |
 | **Interactive Setup** | `scripts/setup.sh` vereint alle Schritte in einem Menü mit Rollback-, Secrets- und Directory-Optionen. |
 | **Fleet-Agent-Installer** | Skripte für Linux & Windows enrollen den Elastic Agent direkt gegen den mitgelieferten Fleet Server. |
@@ -83,6 +83,8 @@ graph LR
    ```bash
    bash scripts/generate-certs.sh
    ```
+   - Bezieht die öffentlichen URLs aus `.env` sowie die Container-Namen (`es01`, `kibana`, `fleet-server`, `caddy`) in jedes Zertifikat mit ein.
+   - Erkennt vorhandene Zertifikate und fragt nach, bevor Schlüssel oder CA ersetzt werden.
 
 4. **Stack starten** – Elasticsearch, Kibana, Fleet Server und Caddy werden hochgefahren.
    ```bash


### PR DESCRIPTION
## Summary
- extend the certificate generator to consolidate SAN entries from .env domains and internal container hostnames
- prompt before overwriting existing certificates and ensure SAN entries are copied into the signed certificates
- document the improved behaviour in the README and changelog

## Testing
- `bash scripts/generate-certs.sh <<'EOF'
y
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68cc09d23874833385777ef725413e97